### PR TITLE
:+1: Imageにmaster_keyを含めないで起動

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+config/master.key
+spec/
+tmp/
+!tmp/pids/
+node_modules/
+vendor/assets/
+
+.env
+.envrc
+# intelliJ
+.idea/
+*.iml
+railways.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,31 @@
 FROM ruby:2.6.5-slim-buster
 
 RUN apt-get update -qq && \
-    apt-get install -y build-essential \
-                       libpq-dev vim \
-                       postgresql-client \
-                       nodejs npm \
-                       locales locales-all
+    apt-get install -y --no-install-recommends \
+    vim locales build-essential \
+    libpq-dev \
+    postgresql-client \
+    nodejs npm &&\
+    npm install -g yarn &&\
+    rm -f /etc/localtime &&\
+    ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime &&\
+    echo 'Asia/Tokyo' > /etc/timezone &&\
+    apt-get clean &&\
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install -y curl apt-transport-https wget && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && apt-get install -y yarn
-
-RUN rm -f /etc/localtime && \
-    ln -fs /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    echo 'Asia/Tokyo' > /etc/timezone
-ENV LANG ja_JP.UTF-8
-RUN update-locale LANG=ja_JP.UTF-8
-RUN ln -s /usr/bin/cronolog /usr/local/sbin/cronolog
 
 ENV APP_ROOT /app
 WORKDIR $APP_ROOT
 
 ADD Gemfile Gemfile.lock package.json yarn.lock $APP_ROOT/
 
-RUN gem install bundler:2.0.2
+RUN gem update --system && gem install bundler:2.0.2
 
 RUN RAILS_ENV=production bundle install
 
 ADD . $APP_ROOT
 
-RUN RAILS_ENV=production bundle exec rake assets:clobber
-RUN RAILS_ENV=production bundle exec rails assets:precompile
+ADD entrypoint.sh /opt/
 
 EXPOSE 3000
-CMD ["rails","server","-b","0.0.0.0"]
+CMD ["bash", "/opt/entrypoint.sh"]

--- a/app/models/shop_congrestion_info.rb
+++ b/app/models/shop_congrestion_info.rb
@@ -11,7 +11,7 @@ class ShopCongrestionInfo < ApplicationRecord
     )
   }
 
-  # 現在とお同じ曜日に投稿された投稿を取得
+  # 現在と同じ曜日に投稿された投稿を取得
   scope :same_about_day_of_week_post, lambda {
     where('extract(dow from created_at) = ?', Time.zone.now.wday)
   }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd /app
+
+# ローカルやQAで動かす際に必要なgemを入れる必要があるので、入れておく。
+RAILS_ENV=${RAILS_ENV:-production} bundle install
+
+# assets:precompile は、RAILS_ENV=productionでコマンド実行時に config/master.key の値を参照する必要がある。
+# しかし、dockerイメージビルド時にクレデンシャル情報を渡すと、イメージ内にその環境変数が残ってしまう。
+# それを避けるために、起動時にこのコマンドを実行している。
+RAILS_ENV=${RAILS_ENV:-production} bundle exec rails assets:precompile
+
+RAILS_ENV=${RAILS_ENV:-production} bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
### 目的
- ImageにRails Master Keyを含めないようにする

#### 概要
- Assets CompileをするときにRailsMasterKeyが必要と言われる
- セキュリティ的にImageにRailsMasterKeyを含めたくない
- SSMパラメータストアでRailsMasterKeyを持たせて、そのKeyを使って、起動時にECSからAssets Compileする
- そのためにentrypoint.shを作成
