### PR TITLE
ArgumentError: invalid value for Integer(): "08"の修正

### DIFF
--- a/db/seeds/create/cities.rb
+++ b/db/seeds/create/cities.rb
@@ -27,7 +27,7 @@ cities_by_uniqed_city_code.each do |data|
   cities << City.new(
     code: data[city_code_index],
     name: data[city_name_index],
-    prefecture_id: format('%01d', data[prefecutre_code_index])
+    prefecture_id: format('%01d', data[prefecutre_code_index].to_i)
   )
 end
 


### PR DESCRIPTION
```
ArgumentError: invalid value for Integer(): "08"
```
>数値を表す書式（この例の"d"）があるときに、埋め込まれるものが文字列だった場合は、数値に変換されるというものです。"07" は8進数の7です。"08" は0で始まっているのに8進数の書式としておかしいのでエラーになります。


